### PR TITLE
fix dimnames issue if BatchInfo was factor with unused levels

### DIFF
--- a/R/FunctionsPart1.R
+++ b/R/FunctionsPart1.R
@@ -124,6 +124,13 @@ newBASiCS_Data <- function(Counts, Tech, SpikeInfo, BatchInfo = NULL)
 {
 
   if(is.null(BatchInfo)) {BatchInfo = rep(1, times = ncol(Counts))}
+  if(is.factor(BatchInfo)) {
+    BIunused <- length(levels(BatchInfo)) - length(unique(BatchInfo))
+    if(BIunused > 0){
+      message(sprintf("Dropping %i unused batch levels", BIunused))
+      BatchInfo <- droplevels(BatchInfo)
+    }
+  }
 
   # Re-ordering genes
   Counts = rbind(Counts[!Tech,], Counts[Tech,])


### PR DESCRIPTION
Dear Catalina,

As per separate email, please find here a suggestion to avoid the `BASiCS_MCMC` function failing due to a `dimnames` issue when the `BatchInfo=` argument of the `newBASiCS_Data` was a factor with unused levels, *e.g.*:

    ff <- factor(x=c('a','b'), levels=c('a','b','c'))

All the best,
Kevin