### PR TITLE
version 1.5.24 (2019-04-05)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: BASiCS
 Type: Package
 Title: Bayesian Analysis of Single-Cell Sequencing data
-Version: 1.5.23
-Date: : 2019-04-02
+Version: 1.5.24
+Date: : 2019-04-05
 Authors@R: c(person("Catalina", "Vallejos", role=c("aut", "cre"),
         email="cnvallej@uc.cl"), 
         person("Nils", "Eling", role=c("aut")), 

--- a/NEWS
+++ b/NEWS
@@ -1143,3 +1143,7 @@ moved from `Methods.R` to `HiddenUtils.R`
 version 1.5.23 (2019-04-02)
 - Minor edit to the documentation of `makeExampleBASiCS_Data` (explain why
 a fixed seed is no longer used)
+
+version 1.5.24 (2019-04-05)
+- Minor edit to the documentation of `makeExampleBASiCS_Data` (fixed link to 
+`set.seed` documentation as it led to WARNINGS in Bioc-devel)

--- a/R/makeExampleBASiCS_Data.R
+++ b/R/makeExampleBASiCS_Data.R
@@ -26,7 +26,7 @@
 #' @details Note: In BASiCS versions < 1.5.22, \code{makeExampleBASiCS_Data} 
 #' used a fixed seed within the function. This has been removed to comply with 
 #' Bioconductor policies. If a reproducible example is required, please use 
-#' \link[base]{set.seed} prior to calling \code{makeExampleBASiCS_Data} .
+#' \code{set.seed} prior to calling \code{makeExampleBASiCS_Data} .
 #'
 #' @author Catalina A. Vallejos \email{cnvallej@@uc.cl}
 #' @author Nils Eling \email{eling@@ebi.ac.uk}


### PR DESCRIPTION
- Minor edit to the documentation of `makeExampleBASiCS_Data` (fixed link to
`set.seed` documentation as it led to WARNINGS in Bioc-devel)