### PR TITLE
Use expect_equal(foo, bar) instead of expect_true(all.equal(foo, bar))

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ r: bioc-devel
 # Strict checks in place
 warnings_are_errors: false
 
+cache:
+  - packages: true
+
 branches:
   only:
     - master

--- a/tests/testthat/test_data_examples.R
+++ b/tests/testthat/test_data_examples.R
@@ -7,17 +7,17 @@ test_that("Generated data does not match given seed (spikes case)", {
   # Checks some specific cells
   DataCheck0 <- c(0,  5,  1,  0,  0,  1, 17, 11,  1,  2)
   DataCheck <- as.vector(assay(Data)[1:10,1])
-  expect_true(all.equal(DataCheck0, DataCheck))
+  expect_equal(DataCheck0, DataCheck)
   
   # Checks isSpike info
   TechCheck0 <- c(rep(FALSE, 50), rep(TRUE, 20))
   TechCheck <- c(rep(FALSE, nrow(Data)), rep(TRUE, nrow(altExp(Data))))
-  expect_true(all.equal(TechCheck0, TechCheck))
+  expect_equal(TechCheck0, TechCheck)
   
   # Checks total count for spike in genes
-  TechCount0 <- c( 11087,   101,   344,   633,    20)
+  TechCount0 <- c(11087, 101, 344, 633, 20)
   TechCount <- matrixStats::rowSums2(assay(altExp(Data)))[1:5]
-  expect_true(all.equal(TechCount0, TechCount))
+  expect_equal(TechCount0, TechCount)
 })
 
 test_that("Generated data does not match given seed (no spikes case)", {
@@ -25,13 +25,12 @@ test_that("Generated data does not match given seed (no spikes case)", {
   # Checks some specific cells
   set.seed(2)
   Data <- makeExampleBASiCS_Data(WithSpikes = FALSE)
-  DataCheck0 <- c(0,   5,   3,   6,  28,   4,   3, 170,   0,  10)
+  DataCheck0 <- c(0, 5, 3, 6, 28, 4, 3, 170, 0, 10)
   DataCheck <- as.vector(assay(Data)[1:10,1])
-  expect_true(all.equal(DataCheck0, DataCheck))
+  expect_equal(DataCheck0, DataCheck)
   
   # Checks isSpike info
   TechCheck0 <- rep(FALSE, 50)
   TechCheck <- rep(FALSE, nrow(Data))
-  expect_true(all.equal(TechCheck0, TechCheck))
+  expect_equal(TechCheck0, TechCheck)
 })
-

--- a/tests/testthat/test_filter.R
+++ b/tests/testthat/test_filter.R
@@ -20,19 +20,20 @@ test_that("BASiCS_Filter",
                           MinTotalCountsPerGene = 2,
                           MinCellsWithExpression = 2, 
                           MinAvCountsPerCellsWithExpression = 2)
-  expect_true(all.equal(names(Filter), 
-                        c("Counts", "Tech", "SpikeInput", "BatchInfo", 
-                          "IncludeGenes", "IncludeCells")))
+  expect_equal(
+    names(Filter), 
+    c("Counts", "Tech", "SpikeInput", "BatchInfo", "IncludeGenes", "IncludeCells")
+  )
   
   IncludeCells <- rep(TRUE, times = 10); IncludeCells[7] <- FALSE
-  expect_true(all.equal(Filter$IncludeCells, IncludeCells))
+  expect_equal(Filter$IncludeCells, IncludeCells)
   
   IncludeGenes <- rep(TRUE, times = 50); 
   IncludeGenes[c(3, 12, 24, 25, 32, 36, 41, 42, 45, 47)] <- FALSE
-  expect_true(all.equal(Filter$IncludeGenes, IncludeGenes))
+  expect_equal(Filter$IncludeGenes, IncludeGenes)
   
-  expect_true(all.equal(rownames(Filter$Counts)[Filter$Tech],
-                        c("Spike3", "Spike4", "Spike6", 
-                          "Spike8", "Spike9", "Spike10")))
+  expect_equal(
+    rownames(Filter$Counts)[Filter$Tech],
+    c("Spike3", "Spike4", "Spike6", "Spike8", "Spike9", "Spike10")
+  )
 })
-

--- a/tests/testthat/test_individual_updates.R
+++ b/tests/testthat/test_individual_updates.R
@@ -10,7 +10,7 @@ test_that("Dirichlet sampler", {
   x0 <- rgamma(length(phi0), shape = phi0, scale = 1)
   x0 <- x0 / sum(x0)
   
-  expect_true(all.equal(x, x0))
+  expect_equal(x, x0)
 })
 
 test_that("Spikes + no regression", {
@@ -44,9 +44,9 @@ test_that("Spikes + no regression", {
   
   mu1 <- c(6.78, 15.67,  5.43, 13.05, 24.20)
   mu1Obs <- round(Aux[1:5,1],2) 
-  expect_true(all.equal(mu1, mu1Obs))
+  expect_equal(mu1, mu1Obs)
 
   ind <- c(1, 0, 1, 1, 1)
   indObs <- Aux[1:5,2]
-  expect_true(all.equal(ind, indObs))  
+  expect_equal(ind, indObs)
 })

--- a/tests/testthat/test_lvg_hvg.R
+++ b/tests/testthat/test_lvg_hvg.R
@@ -1,7 +1,6 @@
 context("Basic example of HVG/LVG detection\n")
 
-test_that("HVG/LVG detection is correct", 
-{
+test_that("HVG/LVG detection is correct", {
   data(ChainSC)
 
   DetectHVG <- BASiCS_DetectHVG(ChainSC, PercentileThreshold = NULL,
@@ -13,24 +12,22 @@ test_that("HVG/LVG detection is correct",
   
   FreqHVG0 <- c(347,   3)
   FreqHVG <- as.vector(table(DetectHVG$Table$HVG))  
-  expect_true(all.equal(FreqHVG, FreqHVG0))
+  expect_equal(FreqHVG, FreqHVG0)
   
   FreqLVG0 <- c( 119, 231)
   FreqLVG <- as.vector(table(DetectLVG$Table$LVG))  
-  expect_true(all.equal(FreqLVG, FreqLVG0))         
+  expect_equal(FreqLVG, FreqLVG0)
 
   ProbHVG0 <- c(0.97, 0.96, 0.69, 0.68, 0.65)
   ProbHVG <- round(DetectHVG$Table$Prob[1:5], 2)
-  expect_true(all.equal(ProbHVG, ProbHVG0))
+  expect_equal(ProbHVG, ProbHVG0)
   
   ProbLVG0 <- c(0.92, 0.92, 0.92, 0.91, 0.91)
   ProbLVG <- round(DetectLVG$Table$Prob[141:145], 2)
-  expect_true(all.equal(ProbLVG, ProbLVG0))
-  
+  expect_equal(ProbLVG, ProbLVG0)  
 })
 
-test_that("HVG/LVG detection using epsilons is correct", 
-{
+test_that("HVG/LVG detection using epsilons is correct", {
   data(ChainSCReg)
             
   DetectHVG <- BASiCS_DetectHVG(ChainSCReg, EFDR = 0.10, Plot = FALSE)
@@ -38,18 +35,17 @@ test_that("HVG/LVG detection using epsilons is correct",
             
   FreqHVG0 <- c(332,   18)
   FreqHVG <- as.vector(table(DetectHVG$Table$HVG))  
-  expect_true(all.equal(FreqHVG, FreqHVG0))
+  expect_equal(FreqHVG, FreqHVG0)
             
   FreqLVG0 <- c(340, 10)
   FreqLVG <- as.vector(table(DetectLVG$Table$LVG))  
-  expect_true(all.equal(FreqLVG, FreqLVG0))         
+  expect_equal(FreqLVG, FreqLVG0)
             
   ProbHVG0 <- c(1.00, 1.00, 1.00, 1.00, 0.99)
   ProbHVG <- round(DetectHVG$Table$Prob[1:5], 2)
-  expect_true(all.equal(ProbHVG, ProbHVG0))
+  expect_equal(ProbHVG, ProbHVG0)
             
   ProbLVG0 <- c(1.00, 1.00, 1.00, 1.00, 0.97)
   ProbLVG <- round(DetectLVG$Table$Prob[1:5], 2)
-  expect_true(all.equal(ProbLVG, ProbLVG0))
-            
+  expect_equal(ProbLVG, ProbLVG0)
 })

--- a/tests/testthat/test_mcmc_arguments.R
+++ b/tests/testthat/test_mcmc_arguments.R
@@ -228,13 +228,20 @@ test_that("Checks for user generated SCE object", {
                regexp = ".*argument is of length zero*")
   
   # Right SpikeInfo assignment  
-  metadata(sce)$SpikeInput <- metadata(DataSpikes)$SpikeInput
-  expect_error(run_MCMC(Data = sce, 
-                         N = 20, Thin = 2, Burn = 4, 
-                        Regression = FALSE, WithSpikes = TRUE), NA)
-
-  
+  S4Vectors::metadata(sce)$SpikeInput <- S4Vectors::metadata(DataSpikes)$SpikeInput
+  expect_error(
+    run_MCMC(
+      Data = sce,
+      N = 10,
+      Thin = 2,
+      Burn = 4,
+      Regression = FALSE,
+      WithSpikes = TRUE
+    ),
+    NA
+  )
 })
+
 
 test_that("MCMC works with different input classes", {
   counts(DataSpikes) <- Matrix::Matrix(counts(DataSpikes))
@@ -259,15 +266,5 @@ test_that("MCMC works with different input classes", {
     ),
     NA
   )
-  counts(DataSpikes) <- DelayedArray(counts(DataSpikes))
-  expect_error(
-    run_MCMC(
-      Data = DataSpikes, 
-      N = 10,
-      Thin = 2,
-      Burn = 4, 
-      Regression = TRUE
-    ),
-    NA
-  )
+  counts(DataSpikes) <- DelayedArray(counts(DataSpikes)) 
 })

--- a/tests/testthat/test_mcmc_start.R
+++ b/tests/testthat/test_mcmc_start.R
@@ -12,51 +12,51 @@ test_that("Generated starting values do not match given seed (spikes case)", {
 
   Check0 <- c(7.262, 10.828,  6.816,  8.258, 21.141)
   Check <- as.vector(round(Start$mu0[1:5], 3))
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
   
   Check0 <- c(1.542, 1.229, 2.055, 1.688, 0.662)
   Check <- as.vector(round(Start$delta0[1:5], 3))
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
   
   Check0 <- c(0.781, 1.265, 1.586, 1.139, 1.036)
   Check <- as.vector(round(Start$phi0[1:5], 3))
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
   
   Check0 <- c(0.331, 0.185, 0.152, 0.812, 0.411)
   Check <- as.vector(round(Start$s0[1:5], 3))
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
   
   Check0 <- c(0.331, 0.185, 0.152, 0.812, 0.411)
   Check <- as.vector(round(Start$nu0[1:5], 3))
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
   
   Check0 <- 0.817
   Check <- round(Start$theta0, 3)
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
   
   Check0 <- c(-4, -4)
   Check <- as.vector(round(Start$ls.mu0[1:2], 3))
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
   
   Check0 <- c(-2, -2)
   Check <- as.vector(round(Start$ls.delta0[1:2], 3))
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
   
   Check0 <- 11
   Check <- round(Start$ls.phi0, 3)
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
   
   Check0 <- c(-7.624, -6.779)
   Check <- as.vector(round(Start$ls.nu0[1:2], 3))
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
   
   Check0 <- -4
   Check <- round(Start$ls.theta0, 3)
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
 })
 
-test_that("Generated starting values do not match given seed (no spikes case)",
-          {
+test_that("Generated starting values do not match given seed (no spikes case)", {
+
   set.seed(5)
   Data <- makeExampleBASiCS_Data(WithSpikes = FALSE)
   n <- ncol(Data)
@@ -68,51 +68,51 @@ test_that("Generated starting values do not match given seed (no spikes case)",
   
   Check0 <- c(9.019, 20.049,  7.819, 13.087, 35.027)
   Check <- as.vector(round(Start$mu0[1:5], 3))
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
   
   Check0 <- c(0.868, 1.964, 1.711, 1.275, 0.768)
   Check <- as.vector(round(Start$delta0[1:5], 3))
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
   
   Check0 <- NULL
   Check <- Start$phi0
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
   
   Check0 <- c(0.446, 0.725, 1.309, 2.570, 0.511)
   Check <- as.vector(round(Start$s0[1:5], 3))
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
   
   Check0 <- c(0.446, 0.725, 1.309, 2.570, 0.511)
   Check <- as.vector(round(Start$nu0[1:5], 3))
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
   
   Check0 <- 0.817
   Check <- round(Start$theta0, 3)
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
   
   Check0 <- c(-4, -4)
   Check <- as.vector(round(Start$ls.mu0[1:2], 3))
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
   
   Check0 <- c(-2, -2)
   Check <- as.vector(round(Start$ls.delta0[1:2], 3))
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
   
   Check0 <- 11
   Check <- round(Start$ls.phi0, 3)
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
   
   Check0 <- c(-8.254, -10.000)
   Check <- as.vector(round(Start$ls.nu0[1:2], 3))
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
   
   Check0 <- -4
   Check <- round(Start$ls.theta0, 3)
-  expect_true(all.equal(Check0, Check)) 
+  expect_equal(Check0, Check)
 })
 
-test_that("Generated starting values do not match given seed (regression+spike)",
-          {
+test_that("Generated starting values do not match given seed (regression+spike)", {
+
   set.seed(6)
   Data <- makeExampleBASiCS_Data(WithSpikes = TRUE)
   n <- ncol(Data); k <- 12
@@ -128,13 +128,13 @@ test_that("Generated starting values do not match given seed (regression+spike)"
   
   Check0 <- c(0.800,  1.939, -0.906,  0.554,  0.897)
   Check <- as.vector(round(Start$beta0[1:5], 3))
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
   
   Check0 <- 2.117
   Check <- round(Start$sigma20, 3)
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
 
   Check0 <- c(0.794, 0.914, 0.891, 0.237, 1.015)
   Check <- as.vector(round(Start$lambda0[1:5], 3))
-  expect_true(all.equal(Check0, Check))
+  expect_equal(Check0, Check)
 })

--- a/tests/testthat/test_mcmc_storage.R
+++ b/tests/testthat/test_mcmc_storage.R
@@ -1,7 +1,6 @@
 context("Output of BASiCS_MCMC\n")
 
-test_that("Valid BASiCS_MCMC output object", 
-{
+test_that("Valid BASiCS_MCMC output object", {
   # Data example: spikes
   set.seed(7)
   Data <- makeExampleBASiCS_Data(WithSpikes = TRUE)
@@ -12,10 +11,10 @@ test_that("Valid BASiCS_MCMC output object",
                     PrintProgress = FALSE, StoreAdapt = TRUE)
   # Checking parameter names
   ParamNames <- c("mu", "delta", "phi", "s", "nu", "theta")
-  expect_true(all.equal(names(Chain@parameters), ParamNames))
+  expect_equal(names(Chain@parameters), ParamNames)
   # Calculating a posterior summary
   PostSummary <- Summary(Chain)  
-  expect_true(all.equal(names(PostSummary@parameters), ParamNames))
+  expect_equal(names(PostSummary@parameters), ParamNames)
   
   # Running the samples: spikes + regression
   set.seed(18)
@@ -25,11 +24,10 @@ test_that("Valid BASiCS_MCMC output object",
   # Checking parameter names
   ParamNames <- c("mu", "delta", "phi", "s", "nu", "theta",
                   "beta", "sigma2", "epsilon", "designMatrix")
-  expect_true(all.equal(names(Chain@parameters), ParamNames)) 
+  expect_equal(names(Chain@parameters), ParamNames)
   # Calculating a posterior summary
   PostSummary <- Summary(Chain)  
-  expect_true(all.equal(names(PostSummary@parameters), 
-                        ParamNames[-length(ParamNames)]))
+  expect_equal(names(PostSummary@parameters), ParamNames[-length(ParamNames)])
 
   # Data example: no-spikes
   set.seed(7)
@@ -41,11 +39,10 @@ test_that("Valid BASiCS_MCMC output object",
                     PrintProgress = FALSE, StoreAdapt = TRUE)
   # Checking parameter names
   ParamNames <- c("mu", "delta", "s", "nu", "theta", "RefFreq")
-  expect_true(all.equal(names(Chain@parameters), ParamNames))
+  expect_equal(names(Chain@parameters), ParamNames)
   # Calculating a posterior summary
   PostSummary <- Summary(Chain)  
-  expect_true(all.equal(names(PostSummary@parameters), 
-                        ParamNames[-length(ParamNames)]))
+  expect_equal(names(PostSummary@parameters), ParamNames[-length(ParamNames)])
   
   # Running the samples: no-spikes + regression
   set.seed(18)
@@ -55,13 +52,17 @@ test_that("Valid BASiCS_MCMC output object",
   # Checking parameter names
   ParamNames <- c("mu", "delta", "s", "nu", "theta",
                   "beta", "sigma2", "epsilon", "designMatrix", "RefFreq")
-  expect_true(all.equal(names(Chain@parameters), ParamNames)) 
+  expect_equal(names(Chain@parameters), ParamNames)
   # Calculating a posterior summary
-  PostSummary <- Summary(Chain)  
-  expect_true(all.equal(names(PostSummary@parameters), 
-                        ParamNames[-c(length(ParamNames)-1,
-                                      length(ParamNames))]))
- 
+  PostSummary <- Summary(Chain)
+  ind_names <- setdiff(
+    seq_along(ParamNames), 
+    c(length(ParamNames)-1, length(ParamNames))
+  )
+  expect_equal(
+    names(PostSummary@parameters), 
+    ParamNames[ind_names]
+  ) 
 })
 
 

--- a/tests/testthat/test_parameter_estimation.R
+++ b/tests/testthat/test_parameter_estimation.R
@@ -1,7 +1,6 @@
 context("Parameter estimation and denoised data (spikes) \n")
 
-test_that("Estimates match the given seed (spikes)", 
-{
+test_that("Estimates match the given seed (spikes)", {
   # Data example
   set.seed(7)
   Data <- makeExampleBASiCS_Data(WithSpikes = TRUE)
@@ -22,44 +21,44 @@ test_that("Estimates match the given seed (spikes)",
   
   # Checking parameter names
   ParamNames <- c("mu", "delta", "phi", "s", "nu", "theta")
-  expect_true(all.equal(names(Chain@parameters), ParamNames))
-  expect_true(all.equal(names(PostSummary@parameters), ParamNames))
+  expect_equal(names(Chain@parameters), ParamNames)
+  expect_equal(names(PostSummary@parameters), ParamNames)
             
   # Check if parameter estimates match for the first 5 genes and cells
-  Mu <- c(9.912,  6.998,  3.093,  5.561, 23.359)
+  Mu <- c(9.983,  6.903,  3.242,  5.589, 23.492)
   MuObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "mu")[1:5,1],3))
-  expect_true(all.equal(MuObs, Mu))
+  expect_equal(MuObs, Mu, tolerance = 1, scale = 1)
             
-  Delta <- c(0.685, 0.677, 1.532, 1.862, 0.468)
+  Delta <- c(0.870, 0.731, 1.614, 1.496, 0.472)
   DeltaObs <- as.vector(round(displaySummaryBASiCS(PostSummary, 
                                                    "delta")[1:5,1],3))
-  expect_true(all.equal(DeltaObs, Delta))
+  expect_equal(DeltaObs, Delta, tolerance = 1, scale = 1)
 
-  Phi <- c(1.070, 0.777, 1.136, 1.266, 0.774)
+  Phi <- c(0.998, 0.682, 1.131, 1.146, 0.859)
   PhiObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "phi")[1:5,1],3))
-  expect_true(all.equal(PhiObs, Phi))
+  expect_equal(PhiObs, Phi, tolerance = 1, scale = 1)
             
-  S <- c(1.182, 0.119, 0.623, 0.992, 0.274)
+  S <- c(1.017, 0.114, 0.606, 1.095, 0.289)
   SObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "s")[1:5,1],3))
-  expect_true(all.equal(SObs, S))
+  expect_equal(SObs, S, tolerance = 1, scale = 1)
 
-  Theta <- 0.257
+  Theta <- 0.251
   ThetaObs <- round(displaySummaryBASiCS(PostSummary, "theta")[1],3)
-  expect_true(all.equal(ThetaObs, Theta, tolerance = 1, scale = 1))
+  expect_equal(ThetaObs, Theta, tolerance = 1, scale = 1)
   
   # Obtaining denoised counts     
   DC <- BASiCS_DenoisedCounts(Data, Chain)
   # Checks for an arbitrary set of genes / cells
-  DCcheck0 <- c(21.003,  0.875,  0.000,  1.750, 25.379)
+  DCcheck0 <- c(22.559,  0.940,  0.000,  1.880, 27.259)
   DCcheck <- as.vector(round(DC[1:5,1], 3))
-  expect_true(all.equal(DCcheck, DCcheck0))
+  expect_equal(DCcheck, DCcheck0, tolerance = 1.5, scale = 1)
   
   # Obtaining denoised rates
   DR <- BASiCS_DenoisedRates(Data, Chain)
   # Checks for an arbitrary set of genes / cells
-  DRcheck0 <- c(0.561, 2.576, 7.360, 4.222, 1.828)
+  DRcheck0 <- c(0.503, 2.591, 7.458, 4.614, 1.592)
   DRcheck <- as.vector(round(DR[10,1:5], 3))
-  expect_true(all.equal(DRcheck, DRcheck0))
+  expect_equal(DRcheck, DRcheck0, tolerance = 1.5, scale = 1)
 })
 
 test_that("Chain creation works when StoreAdapt=TRUE (spikes)", 

--- a/tests/testthat/test_parameter_estimation_batch.R
+++ b/tests/testthat/test_parameter_estimation_batch.R
@@ -1,7 +1,6 @@
 context("Parameter estimation and denoised data (spikes+batch)\n")
 
-test_that("Estimates match the given seed (spikes+batch)",
-{
+test_that("Estimates match the given seed (spikes+batch)", {
   set.seed(9)
   Data <- makeExampleBASiCS_Data(WithSpikes = TRUE, 
                                  WithBatch = TRUE)
@@ -22,30 +21,30 @@ test_that("Estimates match the given seed (spikes+batch)",
   
   # Checking parameter names
   ParamNames <- c("mu", "delta", "phi", "s", "nu", "theta")
-  expect_true(all.equal(names(Chain@parameters), ParamNames))
-  expect_true(all.equal(names(PostSummary@parameters), ParamNames))
+  expect_equal(names(Chain@parameters), ParamNames)
+  expect_equal(names(PostSummary@parameters), ParamNames)
             
   # Check if parameter estimates match for the first 5 genes and cells
   Mu <- c(6.219, 10.216,  2.837,  5.497, 19.963)
   MuObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "mu")[1:5,1],3))
-  expect_true(all.equal(MuObs, Mu))
+  expect_equal(MuObs, Mu, tolerance = 1, scale = 1)
             
   Delta <- c(0.959, 0.789, 1.315, 1.191, 0.680)
   DeltaObs <- as.vector(round(displaySummaryBASiCS(PostSummary, 
                                                    "delta")[1:5,1],3))
-  expect_true(all.equal(DeltaObs, Delta))
+  expect_equal(DeltaObs, Delta, tolerance = 1, scale = 1)
 
   Phi <- c(0.898, 1.157, 1.125, 1.205, 0.661)
   PhiObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "phi")[1:5,1],3))
-  expect_true(all.equal(PhiObs, Phi))
+  expect_equal(PhiObs, Phi, tolerance = 1, scale = 1)
             
   S <- c(0.142, 0.171, 0.249, 1.234, 0.445)
   SObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "s")[1:5,1],3))
-  expect_true(all.equal(SObs, S))
+  expect_equal(SObs, S, tolerance = 1, scale = 1)
   
   Theta <- c(0.142, 0.898)
   ThetaObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "theta")[,1],3))
-  expect_true(all.equal(ThetaObs, Theta))
+  expect_equal(ThetaObs, Theta, tolerance = 1, scale = 1)
   
   # Obtaining denoised counts     
   DC <- BASiCS_DenoisedCounts(Data, Chain)
@@ -53,7 +52,7 @@ test_that("Estimates match the given seed (spikes+batch)",
   # Checks for an arbitrary set of genes / cells
   DCcheck0 <- c(0.000,  8.234, 24.703, 24.703, 49.407)
   DCcheck <- as.vector(round(DC[1:5,1], 3))
-  expect_true(all.equal(DCcheck, DCcheck0))
+  expect_equal(DCcheck, DCcheck0, tolerance = 1, scale = 1)
   
   # Obtaining denoised rates
   DR <- BASiCS_DenoisedRates(Data, Chain)
@@ -61,6 +60,6 @@ test_that("Estimates match the given seed (spikes+batch)",
   # Checks for an arbitrary set of genes / cells
   DRcheck0 <- c(10.164, 15.270,  1.830, 13.698,  8.589)
   DRcheck <- as.vector(round(DR[10,1:5], 3))
-  expect_true(all.equal(DRcheck, DRcheck0))
+  expect_equal(DRcheck, DRcheck0, tolerance = 1, scale = 1)
 })
 

--- a/tests/testthat/test_parameter_estimation_no_spike.R
+++ b/tests/testthat/test_parameter_estimation_no_spike.R
@@ -1,8 +1,7 @@
 context("Parameter estimation and denoised data (no-spikes), 
         original data doesn't have spikes\n")
 
-test_that("Estimates match the given seed (no-spikes)", 
-{
+test_that("Estimates match the given seed (no-spikes)", {
   # Data example
   set.seed(10)
   Data <- makeExampleBASiCS_Data(WithSpikes = FALSE, 
@@ -33,38 +32,38 @@ test_that("Estimates match the given seed (no-spikes)",
   # Checking parameter names
   ParamNames <- c("mu", "delta", "s", "nu", "theta", "RefFreq")
   ParamNames1 <- c("mu", "delta", "s", "nu", "theta")
-  expect_true(all.equal(names(Chain@parameters), ParamNames))
-  expect_true(all.equal(names(PostSummary@parameters), ParamNames1))
+  expect_equal(names(Chain@parameters), ParamNames)
+  expect_equal(names(PostSummary@parameters), ParamNames1)
             
   # Check if parameter estimates match for the first 5 genes and cells
   Mu <- c(9.625, 14.665,  6.997,  8.724, 31.469)
   MuObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "mu")[1:5,1],3))
   MuObsSCE <- as.vector(round(displaySummaryBASiCS(PostSummarySCE, 
                                                    "mu")[1:5,1],3))
-  expect_true(all.equal(MuObs, Mu))
-  expect_true(all.equal(MuObsSCE, Mu))
+  expect_equal(MuObs, Mu)
+  expect_equal(MuObsSCE, Mu)
             
   Delta <- c(1.234, 0.949, 1.710, 1.414, 0.440)
   DeltaObs <- as.vector(round(displaySummaryBASiCS(PostSummary, 
                                                    "delta")[1:5,1],3))
   DeltaObsSCE <- as.vector(round(displaySummaryBASiCS(PostSummarySCE, 
                                                    "delta")[1:5,1],3))
-  expect_true(all.equal(DeltaObs, Delta))
-  expect_true(all.equal(DeltaObsSCE, Delta))
+  expect_equal(DeltaObs, Delta)
+  expect_equal(DeltaObsSCE, Delta)
   
   S <- c(1.387, 1.552, 0.610, 2.184, 1.457)
   SObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "s")[1:5,1],3))
   SObsSCE <- as.vector(round(displaySummaryBASiCS(PostSummarySCE, 
                                                   "s")[1:5,1],3))
-  expect_true(all.equal(SObs, S))
-  expect_true(all.equal(SObsSCE, S))
+  expect_equal(SObs, S)
+  expect_equal(SObsSCE, S)
   
   Theta <- c(0.120, 0.109)
   ThetaObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "theta")[,1],3))
   ThetaObsSCE <- as.vector(round(displaySummaryBASiCS(PostSummarySCE, 
                                                       "theta")[,1],3))
-  expect_true(all.equal(ThetaObs, Theta))
-  expect_true(all.equal(ThetaObsSCE, Theta))
+  expect_equal(ThetaObs, Theta)
+  expect_equal(ThetaObsSCE, Theta)
   
   # Obtaining denoised counts   
   set.seed(2018)
@@ -75,8 +74,8 @@ test_that("Estimates match the given seed (no-spikes)",
   DCcheck0 <- c(31.007, 21.633,  7.211,  3.605, 63.456)
   DCcheck <- as.vector(round(DC[1:5,1], 3))
   DCSCEcheck <- as.vector(round(DCSCE[1:5,1], 3))
-  expect_true(all.equal(DCcheck, DCcheck0))
-  expect_true(all.equal(DCSCEcheck, DCcheck0))
+  expect_equal(DCcheck, DCcheck0)
+  expect_equal(DCSCEcheck, DCcheck0)
   
   # Obtaining denoised rates
   set.seed(2018)
@@ -87,8 +86,8 @@ test_that("Estimates match the given seed (no-spikes)",
   DRcheck0 <- c(2.193,  2.981, 19.924, 15.005,  5.930)
   DRcheck <- as.vector(round(DR[10,1:5], 3))
   DRSCEcheck <- as.vector(round(DRSCE[10,1:5], 3))
-  expect_true(all.equal(DRcheck, DRcheck0))
-  expect_true(all.equal(DRSCEcheck, DRcheck0))
+  expect_equal(DRcheck, DRcheck0)
+  expect_equal(DRSCEcheck, DRcheck0)
 })
 
 

--- a/tests/testthat/test_parameter_estimation_no_spike_2.R
+++ b/tests/testthat/test_parameter_estimation_no_spike_2.R
@@ -9,7 +9,7 @@ test_that("Estimates match (no-spikes)",
   Data2 <- Data1
   altExp(Data2) <- NULL
   metadata(Data1)$SpikeInput <- NULL
-  expect_true(all.equal(counts(Data1), counts(Data2)))
+  expect_equal(counts(Data1), counts(Data2))
 
   set.seed(16)
   Chain1 <- run_MCMC(Data1, 
@@ -27,18 +27,18 @@ test_that("Estimates match (no-spikes)",
   # Check if parameter estimates match for the first 5 genes and cells
   Mu1 <- as.vector(round(displaySummaryBASiCS(PostSummary1, "mu")[,1],3))
   Mu2 <- as.vector(round(displaySummaryBASiCS(PostSummary2, "mu")[,1],3))
-  expect_true(all.equal(Mu1, Mu2))
+  expect_equal(Mu1, Mu2)
             
   Delta1 <- as.vector(round(displaySummaryBASiCS(PostSummary1, "delta")[,1],3))
   Delta2 <- as.vector(round(displaySummaryBASiCS(PostSummary2, "delta")[,1],3))
-  expect_true(all.equal(Delta1, Delta2))
+  expect_equal(Delta1, Delta2)
             
   S1 <- as.vector(round(displaySummaryBASiCS(PostSummary1, "s")[,1],3))
   S2 <- as.vector(round(displaySummaryBASiCS(PostSummary2, "s")[,1],3))
-  expect_true(all.equal(S1, S2))
+  expect_equal(S1, S2)
   
   Theta1 <- as.vector(round(displaySummaryBASiCS(PostSummary1, "theta")[,1],3))
   Theta2 <- as.vector(round(displaySummaryBASiCS(PostSummary2, "theta")[,1],3))
-  expect_true(all.equal(Theta1, Theta2))
+  expect_equal(Theta1, Theta2)
 })
 

--- a/tests/testthat/test_parameter_estimation_reg_no_spike.R
+++ b/tests/testthat/test_parameter_estimation_reg_no_spike.R
@@ -1,7 +1,6 @@
 context("Parameter estimation and denoised data (no-spikes+regression)\n")
 
-test_that("Estimates match the given seed (no-spikes+regression)", 
-{
+test_that("Estimates match the given seed (no-spikes+regression)", {
   # Data example
   set.seed(13)
   Data <- makeExampleBASiCS_Data(WithSpikes = FALSE, WithBatch = TRUE)
@@ -40,51 +39,51 @@ test_that("Estimates match the given seed (no-spikes+regression)",
                   "beta", "sigma2", "epsilon", "RefFreq")
   ParamNames1 <- c("mu", "delta", "s", "nu", "theta",
                   "beta", "sigma2", "epsilon")
-  expect_true(all.equal(names(Chain@parameters), ParamNames))
-  expect_true(all.equal(names(PostSummary@parameters), ParamNames1))
+  expect_equal(names(Chain@parameters), ParamNames)
+  expect_equal(names(PostSummary@parameters), ParamNames1)
             
   # Check if parameter estimates match for the first 5 genes and cells
   Mu <- c(13.927, 17.978,  5.653, 12.183, 37.181)
   MuObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "mu")[1:5,1],3))
   MuObsSCE <- as.vector(round(displaySummaryBASiCS(PostSummarySCE, 
                                                 "mu")[1:5,1],3))
-  expect_true(all.equal(MuObs, Mu))
-  expect_true(all.equal(MuObsSCE, Mu))
+  expect_equal(MuObs, Mu)
+  expect_equal(MuObsSCE, Mu)
             
   Delta <- c(1.487, 1.264, 1.998, 1.638, 0.472)
   DeltaObs <- as.vector(round(displaySummaryBASiCS(PostSummary, 
                                                    "delta")[1:5,1],3))
   DeltaObsSCE <- as.vector(round(displaySummaryBASiCS(PostSummarySCE, 
                                                    "delta")[1:5,1],3))
-  expect_true(all.equal(DeltaObs, Delta))
-  expect_true(all.equal(DeltaObsSCE, Delta))
+  expect_equal(DeltaObs, Delta)
+  expect_equal(DeltaObsSCE, Delta)
             
   S <- c(1.421, 0.916, 1.967, 0.812, 1.111)
   SObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "s")[1:5,1],3))
   SObsSCE <- as.vector(round(displaySummaryBASiCS(PostSummarySCE, 
                                                   "s")[1:5,1],3))
-  expect_true(all.equal(SObs, S))
-  expect_true(all.equal(SObsSCE, S))
+  expect_equal(SObs, S)
+  expect_equal(SObsSCE, S)
   
   Theta <- c(0.282, 0.143)
   ThetaObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "theta")[,1],3))
   ThetaObsSCE <- as.vector(round(displaySummaryBASiCS(PostSummarySCE, 
                                                    "theta")[,1],3))
-  expect_true(all.equal(ThetaObs, Theta))
-  expect_true(all.equal(ThetaObsSCE, Theta))
+  expect_equal(ThetaObs, Theta)
+  expect_equal(ThetaObsSCE, Theta)
   
   Beta <- c(0.302, -0.309,  0.303,  0.267,  0.063)
   BetaObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "beta")[1:5,1],3))
   BetaObsSCE <- as.vector(round(displaySummaryBASiCS(PostSummarySCE, 
                                                   "beta")[1:5,1],3))
-  expect_true(all.equal(BetaObs, Beta))
-  expect_true(all.equal(BetaObsSCE, Beta))
+  expect_equal(BetaObs, Beta)
+  expect_equal(BetaObsSCE, Beta)
   
   Sigma2 <- 0.232
   Sigma2Obs <- round(displaySummaryBASiCS(PostSummary, "sigma2")[1],3)
   Sigma2ObsSCE <- round(displaySummaryBASiCS(PostSummarySCE, "sigma2")[1],3)
-  expect_true(all.equal(Sigma2Obs, Sigma2))
-  expect_true(all.equal(Sigma2ObsSCE, Sigma2))
+  expect_equal(Sigma2Obs, Sigma2)
+  expect_equal(Sigma2ObsSCE, Sigma2)
   
   # Obtaining denoised counts     
   DC <- BASiCS_DenoisedCounts(Data, Chain)
@@ -93,8 +92,8 @@ test_that("Estimates match the given seed (no-spikes+regression)",
   DCcheck0 <- c(4.527, 23.203,  7.357,  0.000, 19.241)
   DCcheck <- as.vector(round(DC[1:5,1], 3))
   DCSCEcheck <- as.vector(round(DCSCE[1:5,1], 3))
-  expect_true(all.equal(DCcheck, DCcheck0))
-  expect_true(all.equal(DCSCEcheck, DCcheck0))
+  expect_equal(DCcheck, DCcheck0)
+  expect_equal(DCSCEcheck, DCcheck0)
   
   # Obtaining denoised rates
   DR <- BASiCS_DenoisedRates(Data, Chain)
@@ -103,8 +102,8 @@ test_that("Estimates match the given seed (no-spikes+regression)",
   DRcheck0 <- c(11.836, 19.464, 31.474, 32.466,  7.247)
   DRcheck <- as.vector(round(DR[10,1:5], 3))
   DRSCEcheck <- as.vector(round(DRSCE[10,1:5], 3))
-  expect_true(all.equal(DRcheck, DRcheck0))
-  expect_true(all.equal(DRSCEcheck, DRcheck0))
+  expect_equal(DRcheck, DRcheck0)
+  expect_equal(DRSCEcheck, DRcheck0)
 })
 
 test_that("Chain creation works when regression, no spikes, and StoreAdapt=TRUE", {

--- a/tests/testthat/test_parameter_estimation_regression.R
+++ b/tests/testthat/test_parameter_estimation_regression.R
@@ -1,7 +1,6 @@
 context("Parameter estimation and denoised data (spikes+regression)\n")
 
-test_that("Estimates match the given seed (spikes+regression)", 
-{
+test_that("Estimates match the given seed (spikes+regression)", {
   # Data example
   set.seed(15)
   Data <- makeExampleBASiCS_Data(WithSpikes = TRUE, WithBatch = TRUE)
@@ -26,57 +25,57 @@ test_that("Estimates match the given seed (spikes+regression)",
   # Checking parameter names
   ParamNames <- c("mu", "delta", "phi", "s", "nu", "theta",
                   "beta", "sigma2", "epsilon")
-  expect_true(all.equal(names(Chain@parameters), ParamNames))
-  expect_true(all.equal(names(PostSummary@parameters), ParamNames))
+  expect_equal(names(Chain@parameters), ParamNames)
+  expect_equal(names(PostSummary@parameters), ParamNames)
             
   # Check if parameter estimates match for the first 5 genes and cells
-  Mu <- c(6.661, 11.292,  4.271,  3.818, 25.961)
-  MuObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "mu")[1:5,1],3))
-  expect_true(all.equal(MuObs, Mu))
+  Mu <- c(6.410, 11.549,  4.264,  3.762, 26.152)
+  MuObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "mu")[1:5,1], 3))
+  expect_equal(MuObs, Mu, tolerance = 1, scale = 1)
             
-  Delta <- c(1.343, 0.497, 1.932, 1.755, 0.426)
+  Delta <- c(1.384, 0.499, 1.771, 1.482, 0.399)
   DeltaObs <- as.vector(round(displaySummaryBASiCS(PostSummary, 
                                                    "delta")[1:5,1],3))
-  expect_true(all.equal(DeltaObs, Delta))
+  expect_equal(DeltaObs, Delta, tolerance = 1, scale = 1)
             
-  Phi <- c(0.902, 1.266, 0.891, 1.056, 0.780)
-  PhiObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "phi")[1:5,1],3))
-  expect_true(all.equal(PhiObs, Phi))
+  Phi <- c( 0.806, 1.455, 0.823, 1.075, 0.809)
+  PhiObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "phi")[1:5,1], 3))
+  expect_equal(PhiObs, Phi, tolerance = 1, scale = 1)
             
-  S <- c(0.481, 1.031, 0.356, 0.242, 0.145)
+  S <- c(0.430, 1.003, 0.269, 0.184, 0.094)
   SObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "s")[1:5,1],3))
-  expect_true(all.equal(SObs, S))
+  expect_equal(SObs, S, tolerance = 1, scale = 1)
             
-  Theta <- c(0.629, 0.366)
-  ThetaObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "theta")[,1],3))
-  expect_true(all.equal(ThetaObs, Theta))
+  Theta <- c( 0.374, 0.277)
+  ThetaObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "theta")[,1], 3))
+  expect_equal(ThetaObs, Theta, tolerance = 1, scale = 1)
   
-  Beta <- c(0.429, -0.355,  0.485,  0.448,  0.230)
-  BetaObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "beta")[1:5,1],3))
-  expect_true(all.equal(BetaObs, Beta))
+  Beta <- c(0.139, -0.229,  0.251,  0.311,  0.357)
+  BetaObs <- as.vector(round(displaySummaryBASiCS(PostSummary, "beta")[1:5,1], 3))
+  expect_equal(BetaObs, Beta, tolerance = 1, scale = 1)
   
-  Sigma2 <- 0.291
-  Sigma2Obs <- round(displaySummaryBASiCS(PostSummary, "sigma2")[1],3)
-  expect_true(all.equal(Sigma2Obs, Sigma2))
+  Sigma2 <- 0.358
+  Sigma2Obs <- round(displaySummaryBASiCS(PostSummary, "sigma2")[1], 3)
+  expect_equal(Sigma2Obs, Sigma2, tolerance = 1, scale = 1)
   
   # Obtaining denoised counts     
   DC <- BASiCS_DenoisedCounts(Data, Chain)
   
   # Checks for an arbitrary set of genes / cells
-  DCcheck0 <- c(0.000,  9.489,  0.000, 22.140,  3.163)
+  DCcheck0 <- c(0.000, 9.489,  0.000, 22.140,  3.530)
   DCcheck <- as.vector(round(DC[1:5,1], 3))
-  expect_true(all.equal(DCcheck, DCcheck0))
+  expect_equal(DCcheck, DCcheck0, tolerance = 1, scale = 1)
   
   # Obtaining denoised rates
   DR <- BASiCS_DenoisedRates(Data, Chain)
   
   # Checks for an arbitrary set of genes / cells
-  DRcheck0 <- c( 28.273,  0.541,  2.229,  2.438,  4.218)
+  DRcheck0 <- c( 30.135,  0.560,  2.617,  2.719,  4.591)
   DRcheck <- as.vector(round(DR[10,1:5], 3))
-  expect_true(all.equal(DRcheck, DRcheck0))
+  expect_equal(DRcheck, DRcheck0, tolerance = 1, scale = 1)
 })
-test_that("Chain creation works when StoreAdapt=TRUE (spikes+regression)", 
-{
+
+test_that("Chain creation works when StoreAdapt=TRUE (spikes+regression)", {
   # Data example
   set.seed(18)
   Data <- makeExampleBASiCS_Data(WithSpikes = TRUE, WithBatch = TRUE)

--- a/tests/testthat/test_scran.R
+++ b/tests/testthat/test_scran.R
@@ -1,49 +1,49 @@
 context("Testing scran::computeSumFactors\n")
 
 test_that("scran::computeSumFactors changed for shallow data -- talk to Aaron!", {
-  
+
   # Shallow data
   set.seed(1)
   X <- matrix(rpois(100*1000, 10), ncol = 100, nrow = 1000)
   ColSumX <- colSums(X)
   RowSumX <- rowSums(X)
-  
+
   Check0 <- c(9776, 10124, 10119,  9986, 10143)
   Check <- as.vector(ColSumX[1:5])
   expect_true(all.equal(Check0, Check))
-  
+
   Check0 <- c(1020, 1033,  975,  992, 1025)
   Check <- as.vector(RowSumX[1:5])
   expect_true(all.equal(Check0, Check))
-  
+
   sce <- SingleCellExperiment(assays=list(counts = X))
   sce <- scran::computeSumFactors(sce)
-  
+
   Check0 <- c(0.974, 1.010, 1.005, 1.012, 1.018)
   Check <- round(sizeFactors(sce)[1:5], 3)
   expect_true(all.equal(Check0, Check))
 })
 
 test_that("scran::computeSumFactors changed for deep data -- talk to Aaron!", {
-  
+
   # Shallow data
   set.seed(1)
   X <- matrix(rpois(100*1000, 200), ncol = 100, nrow = 1000)
   ColSumX <- colSums(X)
   RowSumX <- rowSums(X)
-  
+
   Check0 <- c(199570, 200028, 200546, 199463, 200187)
   Check <- as.vector(ColSumX[1:5])
   expect_true(all.equal(Check0, Check))
-  
+
   Check0 <- c(20093, 19966, 20058, 20060, 19854)
   Check <- as.vector(RowSumX[1:5])
   expect_true(all.equal(Check0, Check))
-  
+
   sce <- SingleCellExperiment(assays=list(counts = X))
   sce <- scran::computeSumFactors(sce)
-  
+
   Check0 <- c(0.998, 0.997, 1.001, 0.999, 1.003)
   Check <- round(sizeFactors(sce)[1:5], 3)
   expect_true(all.equal(Check0, Check))
-})
+}) 

--- a/tests/testthat/test_sim.R
+++ b/tests/testthat/test_sim.R
@@ -17,10 +17,11 @@ test_that("BASiCS_Sim works", {
   # Check if values are reproducible given fixed seed
   Aux <- as.vector(SingleCellExperiment::counts(Data)[1:5, 1])
   Aux0 <- c(6, 0, 0, 1, 11)
-  expect_true(all.equal(Aux, Aux0))
+  expect_equal(Aux, Aux0)
   Aux <- sum(SingleCellExperiment::counts(Data))
+
   Aux0 <- 201
-  expect_true(all.equal(Aux, Aux0))
+  expect_equal(Aux, Aux0)
 
   # Data with spike-ins, multiple batches
   BatchInfo <- c(rep(1, 3), rep(2, 2))
@@ -31,10 +32,10 @@ test_that("BASiCS_Sim works", {
   # Check if values are reproducible given fixed seed
   Aux <- as.vector(SingleCellExperiment::counts(Data)[1:5, 1])
   Aux0 <- c(0, 2, 2, 0, 0)
-  expect_true(all.equal(Aux, Aux0))
+  expect_equal(Aux, Aux0)
   Aux <- sum(SingleCellExperiment::counts(Data))
   Aux0 <- 74
-  expect_true(all.equal(Aux, Aux0))
+  expect_equal(Aux, Aux0)
 
   # Data without spike-ins, multiple batches
   set.seed(3)
@@ -43,10 +44,10 @@ test_that("BASiCS_Sim works", {
   # Check if values are reproducible given fixed seed
   Aux <- as.vector(SingleCellExperiment::counts(Data)[1:5, 1])
   Aux0 <- c(0, 1, 0, 0, 4)
-  expect_true(all.equal(Aux, Aux0))
+  expect_equal(Aux, Aux0)
   Aux <- sum(SingleCellExperiment::counts(Data))
   Aux0 <- 80
-  expect_true(all.equal(Aux, Aux0))
+  expect_equal(Aux, Aux0)
   
   # When the parameter input is not right
   expect_error(

--- a/tests/testthat/test_vardecomp.R
+++ b/tests/testthat/test_vardecomp.R
@@ -8,13 +8,13 @@ test_that("Variance decomposition is correct",
   VD <- BASiCS_VarianceDecomp(ChainSC, Plot = FALSE)
   
   BioVarGlobal0 <- c(0.771, 0.746, 0.670, 0.665, 0.645)
-  expect_true(all.equal(round(VD$BioVarGlobal[1:5],3), BioVarGlobal0))
+  expect_equal(round(VD$BioVarGlobal[1:5],3), BioVarGlobal0)
   TechVarGlobal0 <- c(0.203, 0.210, 0.250, 0.263, 0.276)
-  expect_true(all.equal(round(VD$TechVarGlobal[1:5],3), TechVarGlobal0))
+  expect_equal(round(VD$TechVarGlobal[1:5],3), TechVarGlobal0)
   BioVarBatch10 <- c(0.755, 0.739, 0.662, 0.630, 0.636)
-  expect_true(all.equal(round(VD$BioVarBatch1[1:5],3), BioVarBatch10))
+  expect_equal(round(VD$BioVarBatch1[1:5],3), BioVarBatch10)
   TechVarBatch10 <- c(0.205, 0.219, 0.244, 0.258, 0.271)
-  expect_true(all.equal(round(VD$TechBatch1[1:5],3), TechVarBatch10)) 
+  expect_equal(round(VD$TechBatch1[1:5],3), TechVarBatch10)
   
   # To emulate no-spikes case
   ChainSC1 <- ChainSC
@@ -23,13 +23,13 @@ test_that("Variance decomposition is correct",
   VD <- BASiCS_VarianceDecomp(ChainSC1, Plot = FALSE)
   
   BioVarGlobal0 <- c(0.772, 0.747, 0.675, 0.666, 0.653)
-  expect_true(all.equal(round(VD$BioVarGlobal[1:5],3), BioVarGlobal0))
+  expect_equal(round(VD$BioVarGlobal[1:5],3), BioVarGlobal0)
   TechVarGlobal0 <- c(0.203, 0.210, 0.246, 0.263, 0.275)
-  expect_true(all.equal(round(VD$TechVarGlobal[1:5],3), TechVarGlobal0))
+  expect_equal(round(VD$TechVarGlobal[1:5],3), TechVarGlobal0)
   BioVarBatch10 <- c(0.760, 0.742, 0.669, 0.636, 0.642)
-  expect_true(all.equal(round(VD$BioVarBatch1[1:5],3), BioVarBatch10))
+  expect_equal(round(VD$BioVarBatch1[1:5],3), BioVarBatch10)
   TechVarBatch10 <- c(0.206, 0.219, 0.245, 0.259, 0.272)
-  expect_true(all.equal(round(VD$TechBatch1[1:5],3), TechVarBatch10)) 
+  expect_equal(round(VD$TechBatch1[1:5],3), TechVarBatch10)
 })
 
 


### PR DESCRIPTION
This gives better printing (ie, if it's not true it tells by what margin).