### PR TITLE
version 1.9.20 (2020-02-16)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: BASiCS
 Type: Package
 Title: Bayesian Analysis of Single-Cell Sequencing data
-Version: 1.9.19
-Date: 2020-02-16
+Version: 1.9.20
+Date: 2020-02-19
 Authors@R: c(person("Catalina", "Vallejos", role=c("aut", "cre"),
         email="catalina.vallejos@igmm.ed.ac.uk"), 
         person("Nils", "Eling", role=c("aut")), 

--- a/NEWS
+++ b/NEWS
@@ -1400,3 +1400,8 @@ taking ParamPrior$mu.mu as a vector, rather than a scalar)
 version 1.9.19 (2020-02-16)
 - Adds a while loop in BASiCS_Sim to ensure it doesn't fail if some
   generated cells have zero counts.
+
+version 1.9.20 (2020-02-16)
+- Fix bug in handling of tail probability tests that meant probabilities
+  were not calculated correctly when Epsilon* = 0.
+

--- a/R/BASiCS_TestDE.R
+++ b/R/BASiCS_TestDE.R
@@ -421,7 +421,7 @@ BASiCS_TestDE <- function(Chain1,
 
   # Changes in mean expression
   # Calculating posterior probabilities
-  ProbM <- .TailProb(Chain = abs(ChainTau), Threshold = EpsilonM)
+  ProbM <- .TailProb(Chain = ChainTau, Threshold = EpsilonM)
   AuxMean <- .ThresholdSearch(
     Probs = ProbM[GenesSelect & GoodESS],
     ProbThreshold = ProbThresholdM,
@@ -478,7 +478,7 @@ BASiCS_TestDE <- function(Chain1,
   DeltaSelect <- DeltaSelect & GoodESS
 
 
-  ProbD <- .TailProb(Chain = abs(ChainOmega), Threshold = EpsilonD)
+  ProbD <- .TailProb(Chain = ChainOmega, Threshold = EpsilonD)
   AuxDisp <- .ThresholdSearch(
     Probs = ProbD[DeltaSelect],
     ProbThreshold = ProbThresholdD,
@@ -553,7 +553,7 @@ BASiCS_TestDE <- function(Chain1,
     EpsSelect <- EpsSelect & GoodESS
 
     select <- NotExcluded & GenesSelect
-    ProbE <- .TailProb(Chain = abs(ChainPsi), Threshold = EpsilonR)
+    ProbE <- .TailProb(Chain = ChainPsi, Threshold = EpsilonR)
     AuxResDisp <- .ThresholdSearch(
       Probs = ProbE[EpsSelect],
       ProbThreshold = ProbThresholdR,

--- a/R/utils_Tests.R
+++ b/R/utils_Tests.R
@@ -1,9 +1,9 @@
 .TailProb <- function(Chain, Threshold) {
   if (Threshold > 0) {
-    Prob <- matrixStats::colMeans2(ifelse(abs(Chain) > Threshold, 1, 0))
+    Prob <- matrixStats::colMeans2(abs(Chain) > Threshold)
   }
   else {
-    Prob_aux <- matrixStats::colMeans2(ifelse(Chain > 0, 1, 0))
+    Prob_aux <- matrixStats::colMeans2(Chain > 0)
     Prob <- 2 * pmax(Prob_aux, 1 - Prob_aux) - 1
   }
   return(Prob)

--- a/R/utils_Tests.R
+++ b/R/utils_Tests.R
@@ -1,6 +1,6 @@
 .TailProb <- function(Chain, Threshold) {
   if (Threshold > 0) {
-    Prob <- matrixStats::colMeans2(ifelse(Chain > Threshold, 1, 0))
+    Prob <- matrixStats::colMeans2(ifelse(abs(Chain) > Threshold, 1, 0))
   }
   else {
     Prob_aux <- matrixStats::colMeans2(ifelse(Chain > 0, 1, 0))

--- a/tests/testthat/test_differential_test.R
+++ b/tests/testthat/test_differential_test.R
@@ -137,3 +137,30 @@ test_that("CheckESS works", {
   )
 })
 
+
+
+test_that("EpsilonM = 0 case (reg)", {
+  data(ChainSC)
+  data(ChainRNA)
+
+  Test <- BASiCS_TestDE(
+    Chain1 = ChainSC,
+    Chain2 = ChainRNA,
+    GroupLabel1 = "SC",
+    GroupLabel2 = "P&S",
+    EpsilonM = 0,
+    EpsilonD = 0,
+    OffSet = TRUE,
+    Plot = FALSE,
+    CheckESS = FALSE,
+    PlotOffset = FALSE
+  )
+  expect_equal(
+    as.numeric(table(Test$TableMean$ResultDiffMean)),
+    c(180, 98, 72)
+  )
+  expect_equal(
+    as.numeric(table(Test$TableDisp$ResultDiffDisp)),
+    c(170, 147, 33)
+  )
+})

--- a/tests/testthat/test_differential_test_reg.R
+++ b/tests/testthat/test_differential_test_reg.R
@@ -96,3 +96,35 @@ test_that("CheckESS works", {
   )
 })
 
+
+
+test_that("EpsilonM = 0 case (reg)", {
+  data(ChainSCReg)
+  data(ChainRNAReg)
+
+  Test <- BASiCS_TestDE(
+    Chain1 = ChainSCReg,
+    Chain2 = ChainRNAReg,
+    GroupLabel1 = "SC",
+    GroupLabel2 = "P&S",
+    EpsilonM = 0,
+    EpsilonD = 0,
+    EpsilonR = 0,
+    OffSet = TRUE,
+    Plot = FALSE,
+    CheckESS = FALSE,
+    PlotOffset = FALSE
+  )
+  expect_equal(
+    as.numeric(table(Test$TableMean$ResultDiffMean)),
+    c(150, 119, 81)
+  )
+  expect_equal(
+    as.numeric(table(Test$TableDisp$ResultDiffDisp)),
+    c(200, 98, 52)
+  )
+  expect_equal(
+    as.numeric(table(Test$TableResDisp$ResultDiffResDisp)),
+    c(333, 6, 11)
+  )
+})


### PR DESCRIPTION
Fix bug in handling of tail probability tests such that
Epsilon*=0 was not handled correctly and all probabilities
were reported as exactly 1.